### PR TITLE
Release model-server on Bintray

### DIFF
--- a/model-server/README.md
+++ b/model-server/README.md
@@ -19,3 +19,14 @@ To reformat and add license header to all files run:
 ```
 ./gradlew spotlessApply
 ```
+
+## Perform a release
+
+Insert your bintray credentials under `~/.gradle/gradle.properties`:
+
+```
+bintray_user=yourusername
+bintray_api_key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+Note that you cannot publish versions ending with 'SNAPSHOT'.

--- a/model-server/build.gradle
+++ b/model-server/build.gradle
@@ -1,10 +1,12 @@
 plugins {
     id "application"
     id "com.diffplug.gradle.spotless" version "4.5.1"
+    id 'maven-publish'
 }
 apply plugin: 'java'
 
 group = 'org.modelix'
+description = 'Model Server offering access to model storage'
 version = '1.0-SNAPSHOT'
 
 description = "modelix model server"
@@ -69,5 +71,16 @@ spotless {
                 ' * under the License. \n' +
                 ' */\n' +
                 '\n'
+    }
+}
+
+publishing {
+    publications {
+        modelServer(MavenPublication) {
+            groupId project.group
+            version project.version
+
+            from components.java
+        }
     }
 }

--- a/model-server/build.gradle
+++ b/model-server/build.gradle
@@ -53,7 +53,7 @@ application {
 
 spotless {
     java {
-        googleJavaFormat('1.8').aosp()
+        googleJavaFormat(sourceCompatibility.toString()).aosp()
         licenseHeader '/*\n' +
                 ' * Licensed under the Apache License, Version 2.0 (the "License");\n' +
                 ' * you may not use this file except in compliance with the License.\n' +

--- a/model-server/build.gradle
+++ b/model-server/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id "application"
     id "com.diffplug.gradle.spotless" version "4.5.1"
     id 'maven-publish'
+    id "com.jfrog.bintray" version "1.8.5"
 }
 apply plugin: 'java'
 
@@ -83,4 +84,27 @@ publishing {
             from components.java
         }
     }
+}
+
+bintray {
+    user = rootProject.findProperty('bintray_user')
+    key = rootProject.findProperty('bintray_api_key')
+    pkg {
+        repo = 'modelix-oss-maven'
+        name = project.name
+        userOrg = 'modelix'
+        licenses = ['Apache-2.0']
+        vcsUrl = 'https://github.com/modelix/modelix.git'
+        version {
+            name = 'v' + project.version
+            desc = 'Version ' + project.version
+            released = new Date()
+            vcsTag = 'v'+project.version
+        }
+    }
+
+    publications = ['modelServer']
+    dryRun = false
+    publish = true
+    override = true
 }


### PR DESCRIPTION
This PR configure the model-server so that a maven package can be obtained.
It also configure bintray, in case we want to publish maven packages there (advantage: easy to do).

In case we decide to use bintray, I have registered the organization and I can make someone else the admin.

To do releases you just need to set the credentials from bintray in your gradle properties (described in readme). I have used bintray in other projects and found it easy to use.