### PR TITLE
Publication of model-server fatJar on Maven

### DIFF
--- a/model-server/build.gradle
+++ b/model-server/build.gradle
@@ -54,6 +54,12 @@ task fatJar(type: Jar) {
     with jar
 }
 
+def fatJarFile = file("$buildDir/libs/model-server-fatJar-latest.jar")
+def fatJarArtifact = artifacts.add('archives', fatJarFile) {
+    type 'jar'
+    builtBy 'fatJar'
+}
+
 task cucumber() {
     dependsOn fatJar, compileTestJava
     doLast {
@@ -86,9 +92,10 @@ publishing {
         }
         modelServerFatJar(MavenPublication) {
             groupId project.group
+            artifactId 'model-server-fatjar'
             version project.version
 
-            artifact fatJar
+            artifact fatJarArtifact
         }
     }
 }
@@ -106,7 +113,7 @@ bintray {
             name = 'v' + project.version
             desc = 'Version ' + project.version
             released = new Date()
-            vcsTag = 'v'+project.version
+            vcsTag = 'v' + project.version
         }
     }
 

--- a/model-server/build.gradle
+++ b/model-server/build.gradle
@@ -84,6 +84,12 @@ publishing {
 
             from components.java
         }
+        modelServerFatJar(MavenPublication) {
+            groupId project.group
+            version project.version
+
+            artifact fatJar
+        }
     }
 }
 
@@ -104,7 +110,7 @@ bintray {
         }
     }
 
-    publications = ['modelServer']
+    publications = ['modelServer', 'modelServerFatJar']
     dryRun = false
     publish = true
     override = true

--- a/model-server/src/main/java/org/modelix/model/server/Main.java
+++ b/model-server/src/main/java/org/modelix/model/server/Main.java
@@ -71,10 +71,12 @@ public class Main {
 
         try {
             String portStr = System.getenv("PORT");
+            int port = portStr == null ? 28101 : Integer.parseInt(portStr);
+            LOG.info("Port: " + port);
             InetSocketAddress bindTo =
                     new InetSocketAddress(
                             InetAddress.getByName("0.0.0.0"),
-                            portStr == null ? 28101 : Integer.parseInt(portStr));
+                            port);
             IStoreClient storeClient;
             if (cmdLineArgs.inmemory) {
                 if (cmdLineArgs.jdbcConfFile != null) {


### PR DESCRIPTION
We had already a fatJar being built locally. We now add the publication of this fatJar to maven, so that users can obtain it easily and just run it using `java -jar`, if it makes sense in their case