### PR TITLE
model-server: use MODELIX_SERVER_PORT env var instead of PORT

### DIFF
--- a/model-server/src/main/java/org/modelix/model/server/Main.java
+++ b/model-server/src/main/java/org/modelix/model/server/Main.java
@@ -70,7 +70,7 @@ public class Main {
         LOG.info("Set values: " + cmdLineArgs.setValues);
 
         try {
-            String portStr = System.getenv("PORT");
+            String portStr = System.getenv("MODELIX_SERVER_PORT");
             int port = portStr == null ? 28101 : Integer.parseInt(portStr);
             LOG.info("Port: " + port);
             InetSocketAddress bindTo =


### PR DESCRIPTION
We can use a more specific environment variable, to avoid conflicts with other applications using `PORT`

Fix issue #33 