### PR TITLE
ui, model-server, ui-proxy: increase heap size

### DIFF
--- a/model-server/run-model-server.sh
+++ b/model-server/run-model-server.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-java -Djdbc.url=$jdbc_url -cp "model-server/build/libs/*" org.modelix.model.server.Main
+java -XX:MaxRAMPercentage=100 -Djdbc.url=$jdbc_url -cp "model-server/build/libs/*" org.modelix.model.server.Main

--- a/run-ui-server.sh
+++ b/run-ui-server.sh
@@ -5,6 +5,7 @@ java -DMODEL_URI=$MODEL_URI \
      -Dmodelix.executionMode=CLUSTER \
      -classpath "./*:./mps/lib/*:./dependencies/*" \
      -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5071 \
+     -XX:MaxRAMPercentage=100\
      org.modelix.ui.server.Main
 
 # -agentpath:/opt/cprof/profiler_java_agent.so=-cprof_service=ui

--- a/ui-proxy/Dockerfile
+++ b/ui-proxy/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /usr/ui-proxy
 EXPOSE 33332
 COPY build/libs/* /usr/ui-proxy/
 COPY build/dependencies/* /usr/ui-proxy/
-CMD ["java", "-cp", "/usr/ui-proxy/*", "org.modelix.uiproxy.Main"]
+CMD ["java","-XX:MaxRAMPercentage=100", "-cp", "/usr/ui-proxy/*", "org.modelix.uiproxy.Main"]


### PR DESCRIPTION
Use `-XX:MaxRAMPercentage=100` to increase max heap to 100% of the memory
available to the container. openJDK seems to default to 50% otherwise.