### PR TITLE
ui-proxy, ui, model-server: reduce heap size

### DIFF
--- a/.github/workflows/integrationtests.yml
+++ b/.github/workflows/integrationtests.yml
@@ -24,4 +24,4 @@ jobs:
       with:
         java-version: 11
     - name: Integration Tests
-      run: ./gradlew runIntegrationTests
+      run: ./gradlew -i runIntegrationTests

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+systemProp.org.gradle.internal.http.connectionTimeout=180000
+systemProp.org.gradle.internal.http.socketTimeout=180000

--- a/model-server/run-model-server.sh
+++ b/model-server/run-model-server.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-java -XX:MaxRAMPercentage=100 -Djdbc.url=$jdbc_url -cp "model-server/build/libs/*" org.modelix.model.server.Main
+java -XX:MaxRAMPercentage=85 -Djdbc.url=$jdbc_url -cp "model-server/build/libs/*" org.modelix.model.server.Main

--- a/run-ui-server.sh
+++ b/run-ui-server.sh
@@ -5,7 +5,7 @@ java -DMODEL_URI=$MODEL_URI \
      -Dmodelix.executionMode=CLUSTER \
      -classpath "./*:./mps/lib/*:./dependencies/*" \
      -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5071 \
-     -XX:MaxRAMPercentage=100\
+     -XX:MaxRAMPercentage=85\
      org.modelix.ui.server.Main
 
 # -agentpath:/opt/cprof/profiler_java_agent.so=-cprof_service=ui

--- a/ui-proxy/Dockerfile
+++ b/ui-proxy/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /usr/ui-proxy
 EXPOSE 33332
 COPY build/libs/* /usr/ui-proxy/
 COPY build/dependencies/* /usr/ui-proxy/
-CMD ["java","-XX:MaxRAMPercentage=100", "-cp", "/usr/ui-proxy/*", "org.modelix.uiproxy.Main"]
+CMD ["java","-XX:MaxRAMPercentage=85", "-cp", "/usr/ui-proxy/*", "org.modelix.uiproxy.Main"]


### PR DESCRIPTION
Setting max heap to 100% is to much since we also need some memory for classes and the JVM overhead.
Setting max heap to 100% resulted in sporadic OOM shutdowns of the POD. Especially the ui pod
 which loads lots of classes exceeded the memory limit frequently. Setting it to 85% should
 be a good compromise.