### PR TITLE
ui: add ENV var for heap ratio

### DIFF
--- a/Dockerfile-ui
+++ b/Dockerfile-ui
@@ -6,6 +6,12 @@ EXPOSE 33333
 #  wget -q -O- https://storage.googleapis.com/cloud-profiler/java/latest/profiler_java_agent.tar.gz \
 #  | tar xzv -C /opt/cprof
 
+# Uses by run-ui-server to determine how much of the available memory of the container is used for the JVMs heap.
+# 85% is the default but for projects with lots of plugins loaded into MPS memory required for classloading is large.
+# If lots of memory is allocated for classes the 85% ratio can be to much and the JVM exceeds the memory limit of the
+# container. Containers build on top of the modelix container can simply override the ENV and increase the value.
+ENV HEAP_RATIO=85
+
 COPY build/org.modelix/build/artifacts/org.modelix/plugins/ /usr/modelix-ui/mps/plugins/
 
 COPY artifacts/de.itemis.mps.extensions/ /usr/modelix-ui/mps/plugins/

--- a/run-ui-server.sh
+++ b/run-ui-server.sh
@@ -5,7 +5,7 @@ java -DMODEL_URI=$MODEL_URI \
      -Dmodelix.executionMode=CLUSTER \
      -classpath "./*:./mps/lib/*:./dependencies/*" \
      -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5071 \
-     -XX:MaxRAMPercentage=85\
+     -XX:MaxRAMPercentage="$HEAP_RATIO"\
      org.modelix.ui.server.Main
 
 # -agentpath:/opt/cprof/profiler_java_agent.so=-cprof_service=ui


### PR DESCRIPTION
New environment variable in the Dockerfile-ui called HEAP_RATIO which controls the max heap ratio of the JVM.
85% is the default but for projects with lots of plugins loaded into MPS memory required for classloading is large.
If lots of memory is allocated for classes the 85% ratio can be to much and the JVM exceeds the memory limit of the container.
Containers build on top of the modelix container can simply override the ENV and increase the value.