### PR TITLE
fix virtual package transformation

### DIFF
--- a/mps/org.modelix.ui.sm/models/org.modelix.ui.sm.transformations.mps
+++ b/mps/org.modelix.ui.sm/models/org.modelix.ui.sm.transformations.mps
@@ -1235,9 +1235,8 @@
                   <node concept="2155sH" id="XU9v$rvtHI" role="214sll">
                     <ref role="2155sG" node="7q7cTU0RUlD" resolve="node" />
                   </node>
-                  <node concept="10QFUN" id="XU9v$r$Kpx" role="214sll">
-                    <node concept="10Nm6u" id="XU9v$r$Kpw" role="10QFUP" />
-                    <node concept="17QB3L" id="XU9v$r$N$t" role="10QFUM" />
+                  <node concept="Xl_RD" id="7Pk9fB_fqzG" role="214sll">
+                    <property role="Xl_RC" value="" />
                   </node>
                 </node>
               </node>


### PR DESCRIPTION
Pass empty string instead of null to avoid "missing transformation" exception