### PR TITLE
ui-server: allow loading additional plugins

### DIFF
--- a/ui-server/src/main/java/org/modelix/ui/server/EnvironmentLoader.java
+++ b/ui-server/src/main/java/org/modelix/ui/server/EnvironmentLoader.java
@@ -10,10 +10,12 @@ import jetbrains.mps.project.Project;
 import jetbrains.mps.tool.environment.Environment;
 import jetbrains.mps.tool.environment.EnvironmentConfig;
 import jetbrains.mps.tool.environment.IdeaEnvironment;
+import jetbrains.mps.util.Pair;
 import jetbrains.mps.util.PathManager;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.List;
 
 public class EnvironmentLoader {
 
@@ -25,7 +27,7 @@ public class EnvironmentLoader {
         ourProject = project;
     }
 
-    public static Project loadEnvironment(File gitRepoDir) {
+    public static Project loadEnvironment(File gitRepoDir, List<Pair<String, String>> additionalPlugins) {
         if (ourProject == null) {
             // If you get the exception "Could not find installation home path"
             // Set "-Didea.home" in the VM options
@@ -53,8 +55,12 @@ public class EnvironmentLoader {
                     .addPlugin(new File(pluginsFolder, "org.modelix.ui").getAbsolutePath(), "org.modelix.ui")
                     .addPlugin(new File(pluginsFolder, "org.modelix.model").getAbsolutePath(), "org.modelix.model")
                     .addPlugin(new File(pluginsFolder, "org.modelix.common").getAbsolutePath(), "org.modelix.common")
-                    .addPlugin(new File(pluginsFolder, "org.modelix.ui.server").getAbsolutePath(), "org.modelix.ui.server")
-                    ;
+                    .addPlugin(new File(pluginsFolder, "org.modelix.ui.server").getAbsolutePath(), "org.modelix.ui.server");
+
+            for (Pair<String, String> additionalPlugin : additionalPlugins) {
+                config.addPlugin(new File(pluginsFolder, additionalPlugin.o1).getAbsolutePath(), additionalPlugin.o2);
+            }
+
             if (gitRepoDir != null) {
                 config.addLib(gitRepoDir.getAbsolutePath());
             }

--- a/ui-server/src/main/java/org/modelix/ui/server/Main.java
+++ b/ui-server/src/main/java/org/modelix/ui/server/Main.java
@@ -13,6 +13,7 @@ import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.URIish;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -93,15 +94,18 @@ public class Main {
             }
 
             String additionalPluginsProperty = getPropertyOrEnv("ADDITIONAL_PLUGINS");
-            String[] strings = additionalPluginsProperty.split(",");
+
             List<Pair<String, String>> additionalPlugins = new ArrayList<>();
 
-            for (String pluginsRaw : strings) {
-                if(pluginsRaw.contains(":")) {
-                    String[] split = pluginsRaw.split(":");
-                    additionalPlugins.add(new Pair<>(split[0], split[1]));
-                } else {
-                    additionalPlugins.add(new Pair<>(pluginsRaw, pluginsRaw));
+            if(additionalPluginsProperty != null && additionalPluginsProperty.length() > 0) {
+                String[] strings = additionalPluginsProperty.split(",");
+                for (String pluginsRaw : strings) {
+                    if(pluginsRaw.contains(":")) {
+                        String[] split = pluginsRaw.split(":");
+                        additionalPlugins.add(new Pair<>(split[0], split[1]));
+                    } else {
+                        additionalPlugins.add(new Pair<>(pluginsRaw, pluginsRaw));
+                    }
                 }
             }
 
@@ -138,6 +142,7 @@ public class Main {
         });
     }
 
+    @Nullable
     private static String getPropertyOrEnv(String name) {
         String value = System.getProperty(name);
         if (value == null || value.length() == 0) value = System.getenv(name);

--- a/ui-server/src/main/java/org/modelix/ui/server/Main.java
+++ b/ui-server/src/main/java/org/modelix/ui/server/Main.java
@@ -2,6 +2,7 @@ package org.modelix.ui.server;
 
 import com.google.common.io.Files;
 import jetbrains.mps.project.Project;
+import jetbrains.mps.util.Pair;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.eclipse.jgit.api.CloneCommand;
@@ -15,6 +16,7 @@ import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -90,7 +92,20 @@ public class Main {
                 files.forEach(f -> System.out.println("MPS related file found: " + f));
             }
 
-            Project mpsProject = EnvironmentLoader.loadEnvironment(editableModulesDir);
+            String additionalPluginsProperty = getPropertyOrEnv("ADDITIONAL_PLUGINS");
+            String[] strings = additionalPluginsProperty.split(",");
+            List<Pair<String, String>> additionalPlugins = new ArrayList<>();
+
+            for (String pluginsRaw : strings) {
+                if(pluginsRaw.contains(":")) {
+                    String[] split = pluginsRaw.split(":");
+                    additionalPlugins.add(new Pair<>(split[0], split[1]));
+                } else {
+                    additionalPlugins.add(new Pair<>(pluginsRaw, pluginsRaw));
+                }
+            }
+
+            Project mpsProject = EnvironmentLoader.loadEnvironment(editableModulesDir, additionalPlugins);
             LOG.debug("idea.load.plugins.id: " + System.getProperty("idea.load.plugins.id"));
         } catch (Exception ex) {
             LOG.error("", ex);


### PR DESCRIPTION
Added a new environment variable that allows loading additional plugins.
This is required if modules used in the the image have a idea plugin
facet. If the idea plugin isn't loaded the plugin facet is marked as
invalid and the complete module is marked as invalid by the class loader.
If this happens all dependent modules are also marked as invalid.

The variable supports a comma separated list of plugin id and optionally
the plugin folder if the folder is different from the plugin id.