### PR TITLE
Allow partial loading of repositories

### DIFF
--- a/mps/org.modelix.model.mpsplugin/models/org.modelix.model.mpsplugin.history.mps
+++ b/mps/org.modelix.model.mpsplugin/models/org.modelix.model.mpsplugin.history.mps
@@ -29,7 +29,6 @@
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="bd8o" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application(MPS.IDEA/)" />
     <import index="3a50" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide(MPS.Platform/)" />
-    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
     <import index="fbzs" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.geom(JDK/)" />
     <import index="z2i8" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.icons(MPS.IDEA/)" />
     <import index="xkhl" ref="0a2651ab-f212-45c2-a2f0-343e76cbc26b/java:org.modelix.model.lazy(org.modelix.model.client/)" />
@@ -3288,69 +3287,143 @@
                                 <node concept="3clFbS" id="5JOZTo7orxL" role="1bW5cS">
                                   <node concept="3clFbF" id="5JOZTo7ozTK" role="3cqZAp">
                                     <node concept="2OqwBi" id="5JOZTo7orxU" role="3clFbG">
-                                      <node concept="2OqwBi" id="5JOZTo7orxV" role="2Oq$k0">
-                                        <node concept="3$u5V9" id="5JOZTo7orxW" role="2OqNvi">
-                                          <node concept="1bVj0M" id="5JOZTo7orxX" role="23t8la">
-                                            <node concept="3clFbS" id="5JOZTo7orxY" role="1bW5cS">
-                                              <node concept="3cpWs8" id="5JOZTo7orxZ" role="3cqZAp">
-                                                <node concept="3cpWsn" id="5JOZTo7ory0" role="3cpWs9">
-                                                  <property role="TrG5h" value="tn" />
-                                                  <node concept="3uibUv" id="5JOZTo7ory1" role="1tU5fm">
-                                                    <ref role="3uigEE" to="rgfa:~TreeNode" resolve="TreeNode" />
+                                      <node concept="2OqwBi" id="7lOG3NPqTwn" role="2Oq$k0">
+                                        <node concept="2OqwBi" id="5JOZTo7orxV" role="2Oq$k0">
+                                          <node concept="3$u5V9" id="5JOZTo7orxW" role="2OqNvi">
+                                            <node concept="1bVj0M" id="5JOZTo7orxX" role="23t8la">
+                                              <node concept="3clFbS" id="5JOZTo7orxY" role="1bW5cS">
+                                                <node concept="3cpWs8" id="5JOZTo7orxZ" role="3cqZAp">
+                                                  <node concept="3cpWsn" id="5JOZTo7ory0" role="3cpWs9">
+                                                    <property role="TrG5h" value="tn" />
+                                                    <node concept="3uibUv" id="5JOZTo7ory1" role="1tU5fm">
+                                                      <ref role="3uigEE" to="rgfa:~TreeNode" resolve="TreeNode" />
+                                                    </node>
+                                                    <node concept="10Nm6u" id="7lOG3NPreZZ" role="33vP2m" />
                                                   </node>
-                                                  <node concept="3K4zz7" id="5JOZTo7ory2" role="33vP2m">
-                                                    <node concept="3EllGN" id="5JOZTo7ory3" role="3K4E3e">
-                                                      <node concept="37vLTw" id="5JOZTo7ory4" role="3ElVtu">
-                                                        <ref role="3cqZAo" node="5JOZTo7oryg" resolve="it" />
-                                                      </node>
-                                                      <node concept="37vLTw" id="5JOZTo7ory5" role="3ElQJh">
-                                                        <ref role="3cqZAo" node="5JOZTo7mxJc" resolve="existing" />
-                                                      </node>
-                                                    </node>
-                                                    <node concept="2OqwBi" id="5JOZTo7ory6" role="3K4Cdx">
-                                                      <node concept="37vLTw" id="5JOZTo7ory7" role="2Oq$k0">
-                                                        <ref role="3cqZAo" node="5JOZTo7mxJc" resolve="existing" />
-                                                      </node>
-                                                      <node concept="2Nt0df" id="5JOZTo7ory8" role="2OqNvi">
-                                                        <node concept="37vLTw" id="5JOZTo7ory9" role="38cxEo">
-                                                          <ref role="3cqZAo" node="5JOZTo7oryg" resolve="it" />
+                                                </node>
+                                                <node concept="3J1_TO" id="7lOG3NPqirW" role="3cqZAp">
+                                                  <node concept="3uVAMA" id="7lOG3NPqlly" role="1zxBo5">
+                                                    <node concept="XOnhg" id="7lOG3NPqllz" role="1zc67B">
+                                                      <property role="TrG5h" value="t" />
+                                                      <node concept="nSUau" id="7lOG3NPqll$" role="1tU5fm">
+                                                        <node concept="3uibUv" id="7lOG3NPqm4u" role="nSUat">
+                                                          <ref role="3uigEE" to="wyt6:~Throwable" resolve="Throwable" />
                                                         </node>
                                                       </node>
                                                     </node>
-                                                    <node concept="2ShNRf" id="5JOZTo7orya" role="3K4GZi">
-                                                      <node concept="1pGfFk" id="5JOZTo7oryb" role="2ShVmc">
-                                                        <ref role="37wK5l" node="6aRQr1WUXnx" resolve="RepositoryTreeNode" />
-                                                        <node concept="37vLTw" id="5JOZTo7oryc" role="37wK5m">
-                                                          <ref role="3cqZAo" node="6aRQr1WTIFv" resolve="modelServer" />
+                                                    <node concept="3clFbS" id="7lOG3NPqll_" role="1zc67A">
+                                                      <node concept="3clFbF" id="7lOG3NPqmUs" role="3cqZAp">
+                                                        <node concept="2OqwBi" id="7lOG3NPqnFk" role="3clFbG">
+                                                          <node concept="37vLTw" id="7lOG3NPqmUr" role="2Oq$k0">
+                                                            <ref role="3cqZAo" node="7lOG3NPqllz" resolve="t" />
+                                                          </node>
+                                                          <node concept="liA8E" id="7lOG3NPqof7" role="2OqNvi">
+                                                            <ref role="37wK5l" to="wyt6:~Throwable.printStackTrace()" resolve="printStackTrace" />
+                                                          </node>
                                                         </node>
-                                                        <node concept="37vLTw" id="5JOZTo7oryd" role="37wK5m">
-                                                          <ref role="3cqZAo" node="5JOZTo7oryg" resolve="it" />
+                                                      </node>
+                                                      <node concept="3clFbF" id="7lOG3NPsxrs" role="3cqZAp">
+                                                        <node concept="2YIFZM" id="7lOG3NPsxTq" role="3clFbG">
+                                                          <ref role="37wK5l" to="csg2:7lOG3NPsfuK" resolve="notifyError" />
+                                                          <ref role="1Pybhc" to="csg2:7lOG3NPrKOz" resolve="ModelixNotifications" />
+                                                          <node concept="Xl_RD" id="7lOG3NPsyeq" role="37wK5m">
+                                                            <property role="Xl_RC" value="Repository in invalid state" />
+                                                          </node>
+                                                          <node concept="3cpWs3" id="7lOG3NPsyer" role="37wK5m">
+                                                            <node concept="2OqwBi" id="7lOG3NPsyes" role="3uHU7w">
+                                                              <node concept="37vLTw" id="7lOG3NPsyet" role="2Oq$k0">
+                                                                <ref role="3cqZAo" node="7lOG3NPqllz" resolve="t" />
+                                                              </node>
+                                                              <node concept="liA8E" id="7lOG3NPsyeu" role="2OqNvi">
+                                                                <ref role="37wK5l" to="wyt6:~Throwable.getMessage()" resolve="getMessage" />
+                                                              </node>
+                                                            </node>
+                                                            <node concept="3cpWs3" id="7lOG3NPsyev" role="3uHU7B">
+                                                              <node concept="3cpWs3" id="7lOG3NPsyew" role="3uHU7B">
+                                                                <node concept="Xl_RD" id="7lOG3NPsyex" role="3uHU7B">
+                                                                  <property role="Xl_RC" value="Repository " />
+                                                                </node>
+                                                                <node concept="2OqwBi" id="7lOG3NPsyey" role="3uHU7w">
+                                                                  <node concept="37vLTw" id="7lOG3NPsyez" role="2Oq$k0">
+                                                                    <ref role="3cqZAo" node="5JOZTo7oryg" resolve="it" />
+                                                                  </node>
+                                                                  <node concept="3TrcHB" id="7lOG3NPsye$" role="2OqNvi">
+                                                                    <ref role="3TsBF5" to="w7di:6aRQr1WVbN6" resolve="id" />
+                                                                  </node>
+                                                                </node>
+                                                              </node>
+                                                              <node concept="Xl_RD" id="7lOG3NPsye_" role="3uHU7w">
+                                                                <property role="Xl_RC" value=" cannot be loaded: " />
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                  <node concept="3clFbS" id="7lOG3NPqirY" role="1zxBo7">
+                                                    <node concept="3clFbF" id="7lOG3NPqj_r" role="3cqZAp">
+                                                      <node concept="37vLTI" id="7lOG3NPqj_t" role="3clFbG">
+                                                        <node concept="3K4zz7" id="5JOZTo7ory2" role="37vLTx">
+                                                          <node concept="3EllGN" id="5JOZTo7ory3" role="3K4E3e">
+                                                            <node concept="37vLTw" id="5JOZTo7ory4" role="3ElVtu">
+                                                              <ref role="3cqZAo" node="5JOZTo7oryg" resolve="it" />
+                                                            </node>
+                                                            <node concept="37vLTw" id="5JOZTo7ory5" role="3ElQJh">
+                                                              <ref role="3cqZAo" node="5JOZTo7mxJc" resolve="existing" />
+                                                            </node>
+                                                          </node>
+                                                          <node concept="2OqwBi" id="5JOZTo7ory6" role="3K4Cdx">
+                                                            <node concept="37vLTw" id="5JOZTo7ory7" role="2Oq$k0">
+                                                              <ref role="3cqZAo" node="5JOZTo7mxJc" resolve="existing" />
+                                                            </node>
+                                                            <node concept="2Nt0df" id="5JOZTo7ory8" role="2OqNvi">
+                                                              <node concept="37vLTw" id="5JOZTo7ory9" role="38cxEo">
+                                                                <ref role="3cqZAo" node="5JOZTo7oryg" resolve="it" />
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                          <node concept="2ShNRf" id="5JOZTo7orya" role="3K4GZi">
+                                                            <node concept="1pGfFk" id="5JOZTo7oryb" role="2ShVmc">
+                                                              <ref role="37wK5l" node="6aRQr1WUXnx" resolve="RepositoryTreeNode" />
+                                                              <node concept="37vLTw" id="5JOZTo7oryc" role="37wK5m">
+                                                                <ref role="3cqZAo" node="6aRQr1WTIFv" resolve="modelServer" />
+                                                              </node>
+                                                              <node concept="37vLTw" id="5JOZTo7oryd" role="37wK5m">
+                                                                <ref role="3cqZAo" node="5JOZTo7oryg" resolve="it" />
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                        <node concept="37vLTw" id="7lOG3NPqj_x" role="37vLTJ">
+                                                          <ref role="3cqZAo" node="5JOZTo7ory0" resolve="tn" />
                                                         </node>
                                                       </node>
                                                     </node>
                                                   </node>
                                                 </node>
-                                              </node>
-                                              <node concept="3clFbF" id="5JOZTo7orye" role="3cqZAp">
-                                                <node concept="37vLTw" id="5JOZTo7oryf" role="3clFbG">
-                                                  <ref role="3cqZAo" node="5JOZTo7ory0" resolve="tn" />
+                                                <node concept="3clFbF" id="5JOZTo7orye" role="3cqZAp">
+                                                  <node concept="37vLTw" id="5JOZTo7oryf" role="3clFbG">
+                                                    <ref role="3cqZAo" node="5JOZTo7ory0" resolve="tn" />
+                                                  </node>
                                                 </node>
                                               </node>
+                                              <node concept="Rh6nW" id="5JOZTo7oryg" role="1bW2Oz">
+                                                <property role="TrG5h" value="it" />
+                                                <node concept="2jxLKc" id="5JOZTo7oryh" role="1tU5fm" />
+                                              </node>
                                             </node>
-                                            <node concept="Rh6nW" id="5JOZTo7oryg" role="1bW2Oz">
-                                              <property role="TrG5h" value="it" />
-                                              <node concept="2jxLKc" id="5JOZTo7oryh" role="1tU5fm" />
+                                          </node>
+                                          <node concept="2OqwBi" id="5JOZTo7oryi" role="2Oq$k0">
+                                            <node concept="37vLTw" id="5JOZTo7oryj" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="6aRQr1Xaytw" resolve="info" />
+                                            </node>
+                                            <node concept="3Tsc0h" id="5JOZTo7oryk" role="2OqNvi">
+                                              <ref role="3TtcxE" to="w7di:6aRQr1WVbN2" resolve="repositories" />
                                             </node>
                                           </node>
                                         </node>
-                                        <node concept="2OqwBi" id="5JOZTo7oryi" role="2Oq$k0">
-                                          <node concept="37vLTw" id="5JOZTo7oryj" role="2Oq$k0">
-                                            <ref role="3cqZAo" node="6aRQr1Xaytw" resolve="info" />
-                                          </node>
-                                          <node concept="3Tsc0h" id="5JOZTo7oryk" role="2OqNvi">
-                                            <ref role="3TtcxE" to="w7di:6aRQr1WVbN2" resolve="repositories" />
-                                          </node>
-                                        </node>
+                                        <node concept="1KnU$U" id="7lOG3NPqUY_" role="2OqNvi" />
                                       </node>
                                       <node concept="ANE8D" id="5JOZTo7oryl" role="2OqNvi" />
                                     </node>

--- a/mps/org.modelix.model.mpsplugin/models/org.modelix.model.mpsplugin.mps
+++ b/mps/org.modelix.model.mpsplugin/models/org.modelix.model.mpsplugin.mps
@@ -3104,36 +3104,24 @@
                   <ref role="3cqZAo" node="cwXJrjMCEw" resolve="t" />
                 </node>
               </node>
-              <node concept="3clFbF" id="1ydTf_swdUI" role="3cqZAp">
-                <node concept="2YIFZM" id="1ydTf_swe5f" role="3clFbG">
-                  <ref role="37wK5l" to="fnpx:~Notifications$Bus.notify(com.intellij.notification.Notification)" resolve="notify" />
-                  <ref role="1Pybhd" to="fnpx:~Notifications$Bus" resolve="Notifications.Bus" />
-                  <node concept="2ShNRf" id="1ydTf_sweuI" role="37wK5m">
-                    <node concept="1pGfFk" id="1ydTf_swFJs" role="2ShVmc">
-                      <ref role="37wK5l" to="fnpx:~Notification.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String,com.intellij.notification.NotificationType)" resolve="Notification" />
-                      <node concept="Xl_RD" id="1ydTf_swFWG" role="37wK5m">
-                        <property role="Xl_RC" value="Modelix" />
-                      </node>
-                      <node concept="3cpWs3" id="1ydTf_swGJs" role="37wK5m">
-                        <node concept="37vLTw" id="1ydTf_swGJt" role="3uHU7w">
-                          <ref role="3cqZAo" node="1JFLVobfVqM" resolve="url" />
-                        </node>
-                        <node concept="Xl_RD" id="1ydTf_swGJu" role="3uHU7B">
-                          <property role="Xl_RC" value="Failure while adding model server " />
-                        </node>
-                      </node>
-                      <node concept="2OqwBi" id="1ydTf_swHoz" role="37wK5m">
-                        <node concept="37vLTw" id="1ydTf_swH4r" role="2Oq$k0">
-                          <ref role="3cqZAo" node="cwXJrjMCEw" resolve="t" />
-                        </node>
-                        <node concept="liA8E" id="1ydTf_swHKo" role="2OqNvi">
-                          <ref role="37wK5l" to="wyt6:~Throwable.getMessage()" resolve="getMessage" />
-                        </node>
-                      </node>
-                      <node concept="Rm8GO" id="1ydTf_swIBL" role="37wK5m">
-                        <ref role="Rm8GQ" to="fnpx:~NotificationType.ERROR" resolve="ERROR" />
-                        <ref role="1Px2BO" to="fnpx:~NotificationType" resolve="NotificationType" />
-                      </node>
+              <node concept="3clFbF" id="7lOG3NPsvBz" role="3cqZAp">
+                <node concept="2YIFZM" id="7lOG3NPsvDH" role="3clFbG">
+                  <ref role="37wK5l" node="7lOG3NPsfuK" resolve="notifyError" />
+                  <ref role="1Pybhd" node="7lOG3NPrKOz" resolve="ModelixNotifications" />
+                  <node concept="3cpWs3" id="7lOG3NPsvEu" role="37wK5m">
+                    <node concept="37vLTw" id="7lOG3NPsvEv" role="3uHU7w">
+                      <ref role="3cqZAo" node="1JFLVobfVqM" resolve="url" />
+                    </node>
+                    <node concept="Xl_RD" id="7lOG3NPsvEw" role="3uHU7B">
+                      <property role="Xl_RC" value="Failure while adding model server " />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="7lOG3NPsvEx" role="37wK5m">
+                    <node concept="37vLTw" id="7lOG3NPsvEy" role="2Oq$k0">
+                      <ref role="3cqZAo" node="cwXJrjMCEw" resolve="t" />
+                    </node>
+                    <node concept="liA8E" id="7lOG3NPsvEz" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~Throwable.getMessage()" resolve="getMessage" />
                     </node>
                   </node>
                 </node>
@@ -4178,41 +4166,28 @@
                           <node concept="3Tm1VV" id="46h4oXMtHnn" role="1B3o_S" />
                           <node concept="3cqZAl" id="46h4oXMtHno" role="3clF45" />
                           <node concept="3clFbS" id="46h4oXMtHnp" role="3clF47">
-                            <node concept="3clFbF" id="75_St3$ZyQz" role="3cqZAp">
-                              <node concept="2YIFZM" id="75_St3$ZEVU" role="3clFbG">
-                                <ref role="1Pybhd" to="fnpx:~Notifications$Bus" resolve="Notifications.Bus" />
-                                <ref role="37wK5l" to="fnpx:~Notifications$Bus.notify(com.intellij.notification.Notification)" resolve="notify" />
-                                <node concept="2ShNRf" id="75_St3$ZEVV" role="37wK5m">
-                                  <node concept="1pGfFk" id="75_St3$ZEVW" role="2ShVmc">
-                                    <ref role="37wK5l" to="fnpx:~Notification.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String,com.intellij.notification.NotificationType)" resolve="Notification" />
-                                    <node concept="Xl_RD" id="75_St3$ZEVX" role="37wK5m">
-                                      <property role="Xl_RC" value="Modelix" />
+                            <node concept="3clFbF" id="7lOG3NPsqEP" role="3cqZAp">
+                              <node concept="2YIFZM" id="7lOG3NPsrDA" role="3clFbG">
+                                <ref role="37wK5l" node="7lOG3NPsfuK" resolve="notifyError" />
+                                <ref role="1Pybhd" node="7lOG3NPrKOz" resolve="ModelixNotifications" />
+                                <node concept="Xl_RD" id="7lOG3NPsrF3" role="37wK5m">
+                                  <property role="Xl_RC" value="Forbidden Access" />
+                                </node>
+                                <node concept="3cpWs3" id="7lOG3NPsrF4" role="37wK5m">
+                                  <node concept="3cpWs3" id="7lOG3NPsrF5" role="3uHU7B">
+                                    <node concept="Xl_RD" id="7lOG3NPsrF6" role="3uHU7B">
+                                      <property role="Xl_RC" value="Unauthorized to connect to Model Server " />
                                     </node>
-                                    <node concept="Xl_RD" id="75_St3$ZEVY" role="37wK5m">
-                                      <property role="Xl_RC" value="Forbidden Access" />
+                                    <node concept="37vLTw" id="7lOG3NPsrF7" role="3uHU7w">
+                                      <ref role="3cqZAo" node="46h4oXMu_sX" resolve="baseUrl" />
                                     </node>
-                                    <node concept="3cpWs3" id="75_St3$ZIXK" role="37wK5m">
-                                      <node concept="3cpWs3" id="75_St3$ZIXL" role="3uHU7B">
-                                        <node concept="Xl_RD" id="75_St3$ZIXM" role="3uHU7B">
-                                          <property role="Xl_RC" value="Unauthorized to connect to Model Server " />
-                                        </node>
-                                        <node concept="37vLTw" id="75_St3$ZIXN" role="3uHU7w">
-                                          <ref role="3cqZAo" node="46h4oXMu_sX" resolve="baseUrl" />
-                                        </node>
-                                      </node>
-                                      <node concept="Xl_RD" id="75_St3$ZIXO" role="3uHU7w">
-                                        <property role="Xl_RC" value=". Check you are logged in and have the right to access that Model Server" />
-                                      </node>
-                                    </node>
-                                    <node concept="Rm8GO" id="75_St3$ZEW0" role="37wK5m">
-                                      <ref role="1Px2BO" to="fnpx:~NotificationType" resolve="NotificationType" />
-                                      <ref role="Rm8GQ" to="fnpx:~NotificationType.ERROR" resolve="ERROR" />
-                                    </node>
+                                  </node>
+                                  <node concept="Xl_RD" id="7lOG3NPsrF8" role="3uHU7w">
+                                    <property role="Xl_RC" value=". Check you are logged in and have the right to access that Model Server" />
                                   </node>
                                 </node>
                               </node>
                             </node>
-                            <node concept="3clFbH" id="75_St3$Zy_d" role="3cqZAp" />
                           </node>
                           <node concept="2AHcQZ" id="46h4oXMtHny" role="2AJF6D">
                             <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
@@ -11242,35 +11217,23 @@
         </node>
         <node concept="3clFbJ" id="7PLbr3VCxL4" role="3cqZAp">
           <node concept="3clFbS" id="7PLbr3VCxL6" role="3clFbx">
-            <node concept="3clFbF" id="4S9EsdAOLoO" role="3cqZAp">
-              <node concept="2YIFZM" id="4S9EsdAOLO$" role="3clFbG">
-                <ref role="37wK5l" to="fnpx:~Notifications$Bus.notify(com.intellij.notification.Notification)" resolve="notify" />
-                <ref role="1Pybhd" to="fnpx:~Notifications$Bus" resolve="Notifications.Bus" />
-                <node concept="2ShNRf" id="4S9EsdAOM2j" role="37wK5m">
-                  <node concept="1pGfFk" id="4S9EsdAPmEt" role="2ShVmc">
-                    <ref role="37wK5l" to="fnpx:~Notification.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String,com.intellij.notification.NotificationType)" resolve="Notification" />
-                    <node concept="Xl_RD" id="4S9EsdAPpnE" role="37wK5m">
-                      <property role="Xl_RC" value="modelix" />
+            <node concept="3clFbF" id="7lOG3NPscgG" role="3cqZAp">
+              <node concept="2YIFZM" id="7lOG3NPsh9b" role="3clFbG">
+                <ref role="37wK5l" node="7lOG3NPsfuK" resolve="notifyError" />
+                <ref role="1Pybhd" node="7lOG3NPrKOz" resolve="ModelixNotifications" />
+                <node concept="Xl_RD" id="7lOG3NPsh9A" role="37wK5m">
+                  <property role="Xl_RC" value="Module without ID" />
+                </node>
+                <node concept="3cpWs3" id="7lOG3NPsh9B" role="37wK5m">
+                  <node concept="Xl_RD" id="7lOG3NPsh9C" role="3uHU7w">
+                    <property role="Xl_RC" value=" has been stored without an ID. Please ID and check it out again" />
+                  </node>
+                  <node concept="3cpWs3" id="7lOG3NPsh9D" role="3uHU7B">
+                    <node concept="Xl_RD" id="7lOG3NPsh9E" role="3uHU7B">
+                      <property role="Xl_RC" value="Module " />
                     </node>
-                    <node concept="Xl_RD" id="4S9EsdAPqr_" role="37wK5m">
-                      <property role="Xl_RC" value="Module without ID" />
-                    </node>
-                    <node concept="3cpWs3" id="4S9EsdAPt6E" role="37wK5m">
-                      <node concept="Xl_RD" id="4S9EsdAPtk9" role="3uHU7w">
-                        <property role="Xl_RC" value=" has been stored without an ID. Please ID and check it out again" />
-                      </node>
-                      <node concept="3cpWs3" id="4S9EsdAPs7K" role="3uHU7B">
-                        <node concept="Xl_RD" id="4S9EsdAPqLV" role="3uHU7B">
-                          <property role="Xl_RC" value="Module " />
-                        </node>
-                        <node concept="37vLTw" id="4S9EsdAPsqi" role="3uHU7w">
-                          <ref role="3cqZAo" node="29etMtbjRmI" resolve="name" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="Rm8GO" id="4S9EsdAPBGn" role="37wK5m">
-                      <ref role="Rm8GQ" to="fnpx:~NotificationType.ERROR" resolve="ERROR" />
-                      <ref role="1Px2BO" to="fnpx:~NotificationType" resolve="NotificationType" />
+                    <node concept="37vLTw" id="7lOG3NPsh9F" role="3uHU7w">
+                      <ref role="3cqZAo" node="29etMtbjRmI" resolve="name" />
                     </node>
                   </node>
                 </node>
@@ -40411,6 +40374,111 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
+  </node>
+  <node concept="312cEu" id="7lOG3NPrKOz">
+    <property role="3GE5qa" value="util" />
+    <property role="TrG5h" value="ModelixNotifications" />
+    <node concept="Wx3nA" id="7lOG3NPs_Yi" role="jymVt">
+      <property role="TrG5h" value="GROUP_ID" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7lOG3NPs__p" role="1B3o_S" />
+      <node concept="17QB3L" id="7lOG3NPs_Y3" role="1tU5fm" />
+      <node concept="Xl_RD" id="7lOG3NPsAbv" role="33vP2m">
+        <property role="Xl_RC" value="modelix" />
+      </node>
+    </node>
+    <node concept="2YIFZL" id="7lOG3NPsfuK" role="jymVt">
+      <property role="TrG5h" value="notifyError" />
+      <node concept="3clFbS" id="7lOG3NPsfuM" role="3clF47">
+        <node concept="3clFbF" id="7lOG3NPsfuN" role="3cqZAp">
+          <node concept="2YIFZM" id="7lOG3NPsfuO" role="3clFbG">
+            <ref role="37wK5l" to="fnpx:~Notifications$Bus.notify(com.intellij.notification.Notification)" resolve="notify" />
+            <ref role="1Pybhd" to="fnpx:~Notifications$Bus" resolve="Notifications.Bus" />
+            <node concept="2ShNRf" id="7lOG3NPsfuP" role="37wK5m">
+              <node concept="1pGfFk" id="7lOG3NPsfuQ" role="2ShVmc">
+                <ref role="37wK5l" to="fnpx:~Notification.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String,com.intellij.notification.NotificationType)" resolve="Notification" />
+                <node concept="37vLTw" id="7lOG3NPsAAh" role="37wK5m">
+                  <ref role="3cqZAo" node="7lOG3NPs_Yi" resolve="GROUP_ID" />
+                </node>
+                <node concept="37vLTw" id="7lOG3NPsfuS" role="37wK5m">
+                  <ref role="3cqZAo" node="7lOG3NPsfuX" resolve="title" />
+                </node>
+                <node concept="37vLTw" id="7lOG3NPsfuT" role="37wK5m">
+                  <ref role="3cqZAo" node="7lOG3NPsfuZ" resolve="message" />
+                </node>
+                <node concept="Rm8GO" id="7lOG3NPsfuU" role="37wK5m">
+                  <ref role="Rm8GQ" to="fnpx:~NotificationType.ERROR" resolve="ERROR" />
+                  <ref role="1Px2BO" to="fnpx:~NotificationType" resolve="NotificationType" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="7lOG3NPsfuW" role="3clF45" />
+      <node concept="37vLTG" id="7lOG3NPsfuX" role="3clF46">
+        <property role="TrG5h" value="title" />
+        <node concept="17QB3L" id="7lOG3NPsfuY" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="7lOG3NPsfuZ" role="3clF46">
+        <property role="TrG5h" value="message" />
+        <node concept="17QB3L" id="7lOG3NPsfv0" role="1tU5fm" />
+      </node>
+      <node concept="3Tm1VV" id="7lOG3NPsfuV" role="1B3o_S" />
+    </node>
+    <node concept="2YIFZL" id="7lOG3NPs_8z" role="jymVt">
+      <property role="TrG5h" value="notifyError" />
+      <node concept="3clFbS" id="7lOG3NPs_8$" role="3clF47">
+        <node concept="3clFbF" id="7lOG3NPs_8_" role="3cqZAp">
+          <node concept="2YIFZM" id="7lOG3NPs_8A" role="3clFbG">
+            <ref role="1Pybhd" to="fnpx:~Notifications$Bus" resolve="Notifications.Bus" />
+            <ref role="37wK5l" to="fnpx:~Notifications$Bus.notify(com.intellij.notification.Notification,com.intellij.openapi.project.Project)" resolve="notify" />
+            <node concept="2ShNRf" id="7lOG3NPs_8B" role="37wK5m">
+              <node concept="1pGfFk" id="7lOG3NPs_8C" role="2ShVmc">
+                <ref role="37wK5l" to="fnpx:~Notification.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String,com.intellij.notification.NotificationType)" resolve="Notification" />
+                <node concept="37vLTw" id="7lOG3NPsACj" role="37wK5m">
+                  <ref role="3cqZAo" node="7lOG3NPs_Yi" resolve="GROUP_ID" />
+                </node>
+                <node concept="37vLTw" id="7lOG3NPs_8E" role="37wK5m">
+                  <ref role="3cqZAo" node="7lOG3NPs_8I" resolve="title" />
+                </node>
+                <node concept="37vLTw" id="7lOG3NPs_8F" role="37wK5m">
+                  <ref role="3cqZAo" node="7lOG3NPs_8K" resolve="message" />
+                </node>
+                <node concept="Rm8GO" id="7lOG3NPs_8G" role="37wK5m">
+                  <ref role="1Px2BO" to="fnpx:~NotificationType" resolve="NotificationType" />
+                  <ref role="Rm8GQ" to="fnpx:~NotificationType.ERROR" resolve="ERROR" />
+                </node>
+              </node>
+            </node>
+            <node concept="2YIFZM" id="fizU0316HO" role="37wK5m">
+              <ref role="1Pybhd" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+              <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
+              <node concept="37vLTw" id="7lOG3NPsFZl" role="37wK5m">
+                <ref role="3cqZAo" node="7lOG3NPs_aQ" resolve="mpsProject" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="7lOG3NPs_8H" role="3clF45" />
+      <node concept="37vLTG" id="7lOG3NPs_8I" role="3clF46">
+        <property role="TrG5h" value="title" />
+        <node concept="17QB3L" id="7lOG3NPs_8J" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="7lOG3NPs_8K" role="3clF46">
+        <property role="TrG5h" value="message" />
+        <node concept="17QB3L" id="7lOG3NPs_8L" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="7lOG3NPs_aQ" role="3clF46">
+        <property role="TrG5h" value="mpsProject" />
+        <node concept="3uibUv" id="7lOG3NPs_sc" role="1tU5fm">
+          <ref role="3uigEE" to="z1c4:~MPSProject" resolve="MPSProject" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7lOG3NPs_8M" role="1B3o_S" />
+    </node>
+    <node concept="3Tm1VV" id="7lOG3NPrKO$" role="1B3o_S" />
   </node>
 </model>
 

--- a/mps/org.modelix.model.mpsplugin/models/org.modelix.model.mpsplugin.plugin.mps
+++ b/mps/org.modelix.model.mpsplugin/models/org.modelix.model.mpsplugin.plugin.mps
@@ -2331,69 +2331,53 @@
               </node>
               <node concept="3clFbJ" id="fizU030Hm0" role="3cqZAp">
                 <node concept="3clFbS" id="fizU030Hm2" role="3clFbx">
-                  <node concept="3clFbF" id="fizU030Poi" role="3cqZAp">
-                    <node concept="2YIFZM" id="fizU030Ppg" role="3clFbG">
-                      <ref role="1Pybhc" to="fnpx:~Notifications$Bus" resolve="Notifications.Bus" />
-                      <ref role="37wK5l" to="fnpx:~Notifications$Bus.notify(com.intellij.notification.Notification,com.intellij.openapi.project.Project)" resolve="notify" />
-                      <node concept="2ShNRf" id="fizU030PpG" role="37wK5m">
-                        <node concept="1pGfFk" id="fizU0311e_" role="2ShVmc">
-                          <ref role="37wK5l" to="fnpx:~Notification.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String,com.intellij.notification.NotificationType)" resolve="Notification" />
-                          <node concept="Xl_RD" id="fizU0311kj" role="37wK5m">
-                            <property role="Xl_RC" value="Modelix" />
-                          </node>
-                          <node concept="Xl_RD" id="fizU0311lH" role="37wK5m">
-                            <property role="Xl_RC" value="Unable to unwrap concept" />
-                          </node>
-                          <node concept="3cpWs3" id="fizU03154L" role="37wK5m">
-                            <node concept="Xl_RD" id="fizU03155u" role="3uHU7w">
-                              <property role="Xl_RC" value=")" />
-                            </node>
-                            <node concept="3cpWs3" id="fizU03131b" role="3uHU7B">
-                              <node concept="3cpWs3" id="fizU0312UL" role="3uHU7B">
-                                <node concept="3cpWs3" id="fizU03121g" role="3uHU7B">
-                                  <node concept="Xl_RD" id="fizU0311rx" role="3uHU7B">
-                                    <property role="Xl_RC" value="We were unable to unwrap concept " />
-                                  </node>
-                                  <node concept="2OqwBi" id="fizU0312lN" role="3uHU7w">
-                                    <node concept="37vLTw" id="fizU03122H" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="4mhRRpyE_IH" resolve="concept" />
-                                    </node>
-                                    <node concept="liA8E" id="fizU0312vk" role="2OqNvi">
-                                      <ref role="37wK5l" to="jks5:~IConcept.getLongName()" resolve="getLongName" />
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="Xl_RD" id="fizU0312Vc" role="3uHU7w">
-                                  <property role="Xl_RC" value=" (" />
-                                </node>
+                  <node concept="3clFbF" id="7lOG3NPsDra" role="3cqZAp">
+                    <node concept="2YIFZM" id="7lOG3NPsDvL" role="3clFbG">
+                      <ref role="1Pybhc" to="csg2:7lOG3NPrKOz" resolve="ModelixNotifications" />
+                      <ref role="37wK5l" to="csg2:7lOG3NPs_8z" resolve="notifyError" />
+                      <node concept="Xl_RD" id="7lOG3NPsEce" role="37wK5m">
+                        <property role="Xl_RC" value="Unable to unwrap concept" />
+                      </node>
+                      <node concept="3cpWs3" id="7lOG3NPsEcf" role="37wK5m">
+                        <node concept="Xl_RD" id="7lOG3NPsEcg" role="3uHU7w">
+                          <property role="Xl_RC" value=")" />
+                        </node>
+                        <node concept="3cpWs3" id="7lOG3NPsEch" role="3uHU7B">
+                          <node concept="3cpWs3" id="7lOG3NPsEci" role="3uHU7B">
+                            <node concept="3cpWs3" id="7lOG3NPsEcj" role="3uHU7B">
+                              <node concept="Xl_RD" id="7lOG3NPsEck" role="3uHU7B">
+                                <property role="Xl_RC" value="We were unable to unwrap concept " />
                               </node>
-                              <node concept="2OqwBi" id="fizU0313QJ" role="3uHU7w">
-                                <node concept="2OqwBi" id="fizU0313mE" role="2Oq$k0">
-                                  <node concept="37vLTw" id="fizU03133k" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="4mhRRpyE_IH" resolve="concept" />
-                                  </node>
-                                  <node concept="liA8E" id="fizU0313wD" role="2OqNvi">
-                                    <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
-                                  </node>
+                              <node concept="2OqwBi" id="7lOG3NPsEcl" role="3uHU7w">
+                                <node concept="37vLTw" id="7lOG3NPsEcm" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="4mhRRpyE_IH" resolve="concept" />
                                 </node>
-                                <node concept="liA8E" id="fizU0314GH" role="2OqNvi">
-                                  <ref role="37wK5l" to="wyt6:~Class.getCanonicalName()" resolve="getCanonicalName" />
+                                <node concept="liA8E" id="7lOG3NPsEcn" role="2OqNvi">
+                                  <ref role="37wK5l" to="jks5:~IConcept.getLongName()" resolve="getLongName" />
                                 </node>
                               </node>
                             </node>
+                            <node concept="Xl_RD" id="7lOG3NPsEco" role="3uHU7w">
+                              <property role="Xl_RC" value=" (" />
+                            </node>
                           </node>
-                          <node concept="Rm8GO" id="fizU0315Nh" role="37wK5m">
-                            <ref role="Rm8GQ" to="fnpx:~NotificationType.ERROR" resolve="ERROR" />
-                            <ref role="1Px2BO" to="fnpx:~NotificationType" resolve="NotificationType" />
+                          <node concept="2OqwBi" id="7lOG3NPsEcp" role="3uHU7w">
+                            <node concept="2OqwBi" id="7lOG3NPsEcq" role="2Oq$k0">
+                              <node concept="37vLTw" id="7lOG3NPsEcr" role="2Oq$k0">
+                                <ref role="3cqZAo" node="4mhRRpyE_IH" resolve="concept" />
+                              </node>
+                              <node concept="liA8E" id="7lOG3NPsEcs" role="2OqNvi">
+                                <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="7lOG3NPsEct" role="2OqNvi">
+                              <ref role="37wK5l" to="wyt6:~Class.getCanonicalName()" resolve="getCanonicalName" />
+                            </node>
                           </node>
                         </node>
                       </node>
-                      <node concept="2YIFZM" id="fizU0316HO" role="37wK5m">
-                        <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
-                        <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
-                        <node concept="37vLTw" id="fizU0316LC" role="37wK5m">
-                          <ref role="3cqZAo" node="4mhRRpyEJ3q" resolve="project" />
-                        </node>
+                      <node concept="37vLTw" id="7lOG3NPsECT" role="37wK5m">
+                        <ref role="3cqZAo" node="4mhRRpyEJ3q" resolve="project" />
                       </node>
                     </node>
                   </node>

--- a/mps/test.org.modelix.model.mpsplugin/models/test.org.modelix.model.mpsplugin@tests.mps
+++ b/mps/test.org.modelix.model.mpsplugin/models/test.org.modelix.model.mpsplugin@tests.mps
@@ -571,11 +571,11 @@
             <node concept="3cpWsn" id="6hBdEE_hRAA" role="3cpWs9">
               <property role="TrG5h" value="binding" />
               <node concept="3uibUv" id="6hBdEE_jeho" role="1tU5fm">
-                <ref role="3uigEE" to="csg2:4_k_9wJt0QR" resolve="_ModelBinding" />
+                <ref role="3uigEE" to="csg2:4_k_9wJt0QR" resolve="ModelBinding" />
               </node>
               <node concept="2ShNRf" id="6hBdEE_hVTh" role="33vP2m">
                 <node concept="1pGfFk" id="6hBdEE_hVDL" role="2ShVmc">
-                  <ref role="37wK5l" to="csg2:4_k_9wJtBLu" resolve="_ModelBinding" />
+                  <ref role="37wK5l" to="csg2:4_k_9wJtBLu" resolve="ModelBinding" />
                   <node concept="37vLTw" id="6hBdEE_j8IQ" role="37wK5m">
                     <ref role="3cqZAo" node="6hBdEE_j49l" resolve="modelNodeId" />
                   </node>
@@ -599,7 +599,7 @@
                 <ref role="37wK5l" to="csg2:74bn2Kw$if_" resolve="setOwner" />
                 <node concept="2ShNRf" id="6hBdEE_zE7A" role="37wK5m">
                   <node concept="1pGfFk" id="6hBdEE_zISg" role="2ShVmc">
-                    <ref role="37wK5l" to="csg2:6hBdEE_zKnQ" resolve="_RootBinding" />
+                    <ref role="37wK5l" to="csg2:6hBdEE_zKnQ" resolve="RootBinding" />
                     <node concept="2ShNRf" id="6hBdEE_$q$f" role="37wK5m">
                       <node concept="1pGfFk" id="6hBdEE_$ray" role="2ShVmc">
                         <ref role="37wK5l" to="csg2:6hBdEE_zUqA" resolve="TestCloudRepository" />


### PR DESCRIPTION
Currently, I have a Model Server instance containing many repositories. An issue is preventing one repository to be loaded. That is a problem on its own (some key is missing), however, another problem is the fact that no repositories are loaded at all in the Cloud View. This PR changes that: when an issue is encountered in loading a repository the user is notified and the repository is skipped, allowing other repositories to be loaded.