### PR TITLE
Open project in gradle plugin

### DIFF
--- a/gradle-plugin-test/build.gradle
+++ b/gradle-plugin-test/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath group: 'org.modelix', name: 'gradle-plugin', version: '2020.3.5-202112171217-SNAPSHOT'
+        classpath group: 'org.modelix', name: 'gradle-plugin', version: '2020.3.5-202201200839-SNAPSHOT'
     }
 }
 
@@ -34,31 +34,31 @@ def pluginsDirFromExtensions = [
         "mps-apache-commons"]
 
 modelixModel {
-    serverUrl = "https://mymodelserver.com"
-    repositoryId = "repo3"
-    timeout = 1800
+    serverUrl = "https://myserver.com/"
+    repositoryId = "repo4"
+    timeout = 25000
 
-    // MPS Extensions
-    addLibraryDir(new File("${mpsExtensionsDir.getAbsolutePath()}/mps-apache-commons"))
-    addLibraryDir(new File("${mpsExtensionsDir.getAbsolutePath()}/de.60.mps.libs"))
-    addLibraryDir(new File("${mpsExtensionsDir.getAbsolutePath()}/de.q60.shadowmodels"))
-    addLibraryDir(new File("${mpsExtensionsDir.getAbsolutePath()}/org.modelix.model.api"))
-    addPlugin("${mpsExtensionsDir.getAbsolutePath()}/mps-apache-commons", "org.apache.commons")
-    addPlugin("${mpsExtensionsDir.getAbsolutePath()}/de.60.mps.libs", "de.q60.mps.libs")
-    addPlugin("${mpsExtensionsDir.getAbsolutePath()}/de.q60.shadowmodels", "de.q60.shadowmodels")
-    addPlugin("${mpsExtensionsDir.getAbsolutePath()}/org.modelix.model.api", "org.modelix.model.api")
-
-    // Mbeddr platform
-    addPluginDir(mbeddrDir, ["org.modelix.model.api"])
-
-    // Iets3
-    addPluginDir(iets3Dir)
-
-    // Modelix
-    addLibraryDir(new File(modelixDir, "org.modelix.common"))
-    addLibraryDir(new File(modelixDir, "org.modelix.model"))
-    addPluginDir(new File(modelixDir, "org.modelix.common"))
-    addPluginDir(new File(modelixDir, "org.modelix.model"))
+//    // MPS Extensions
+//    addLibraryDir(new File("${mpsExtensionsDir.getAbsolutePath()}/mps-apache-commons"))
+//    addLibraryDir(new File("${mpsExtensionsDir.getAbsolutePath()}/de.60.mps.libs"))
+//    addLibraryDir(new File("${mpsExtensionsDir.getAbsolutePath()}/de.q60.shadowmodels"))
+//    addLibraryDir(new File("${mpsExtensionsDir.getAbsolutePath()}/org.modelix.model.api"))
+//    addPlugin("${mpsExtensionsDir.getAbsolutePath()}/mps-apache-commons", "org.apache.commons")
+//    addPlugin("${mpsExtensionsDir.getAbsolutePath()}/de.60.mps.libs", "de.q60.mps.libs")
+//    addPlugin("${mpsExtensionsDir.getAbsolutePath()}/de.q60.shadowmodels", "de.q60.shadowmodels")
+//    addPlugin("${mpsExtensionsDir.getAbsolutePath()}/org.modelix.model.api", "org.modelix.model.api")
+//
+//    // Mbeddr platform
+//    addPluginDir(mbeddrDir, ["org.modelix.model.api"])
+//
+//    // Iets3
+//    addPluginDir(iets3Dir)
+//
+//    // Modelix
+//    addLibraryDir(new File(modelixDir, "org.modelix.common"))
+//    addLibraryDir(new File(modelixDir, "org.modelix.model"))
+//    addPluginDir(new File(modelixDir, "org.modelix.common"))
+//    addPluginDir(new File(modelixDir, "org.modelix.model"))
 
     // Add languages specific for the project
 }

--- a/gradle-plugin/src/main/java/org/modelix/gradle/model/EnvironmentLoader.java
+++ b/gradle-plugin/src/main/java/org/modelix/gradle/model/EnvironmentLoader.java
@@ -11,7 +11,6 @@ import jetbrains.mps.tool.environment.Environment;
 import jetbrains.mps.tool.environment.EnvironmentConfig;
 import jetbrains.mps.tool.environment.IdeaEnvironment;
 import jetbrains.mps.util.PathManager;
-import jetbrains.mps.tool.common.PluginData;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -21,7 +20,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -40,7 +38,7 @@ public class EnvironmentLoader {
         ADDITIONAL_PLUGIN_DIRS("additionalPluginDirs"),
         MPS_EXTENSIONS_PATH("mpsExtensionsPath"),
         MODELIX_PATH("modelixPath"),
-        DEBUG("debug");
+        PROJECT("project");
 
         private String code;
 
@@ -257,8 +255,13 @@ public class EnvironmentLoader {
             environment = new IdeaEnvironment(config);
             RuntimeFlags.setTestMode(TestMode.NONE);
             try {
+                File projectFile = Key.PROJECT.readPropertyAsFile();
                 ((IdeaEnvironment) environment).init();
-                ourProject = environment.createEmptyProject();
+                if (projectFile == null) {
+                    ourProject = environment.createEmptyProject();
+                } else {
+                    ourProject = environment.openProject(projectFile);
+                }
             } catch (Throwable e) {
                 throw new RuntimeException("Issue with initializing environment and creating empty project", e);
             }

--- a/gradle-plugin/src/main/java/org/modelix/gradle/model/ModelPlugin.java
+++ b/gradle-plugin/src/main/java/org/modelix/gradle/model/ModelPlugin.java
@@ -26,13 +26,6 @@ public class ModelPlugin implements Plugin<Project> {
     public void apply(Project project_) {
         ModelixModelSettings settings = project_.getExtensions().create("modelixModel", ModelixModelSettings.class);
         project_.afterEvaluate((Project project) -> {
-//            System.out.println("===========================");
-//            System.out.println("Modelix model plugin loaded");
-//            System.out.println("===========================");
-//            System.out.println("  settings loaded from modelixModel.");
-//            System.out.println("  mps path            : " + settings.getMpsPath());
-//            System.out.println("  mps extensions path : " + settings.getMpsExtensionsArtifactsPath());
-//            System.out.println("  modelix path        : " + settings.getModelixArtifactsPath());
             settings.validate();
 
             Manifest manifest = readManifest();
@@ -128,21 +121,6 @@ public class ModelPlugin implements Plugin<Project> {
                 javaExec.setIgnoreExitValue(true);
                 javaExec.setMain(ExportMain.class.getName());
                 javaExec.doLast(task -> {
-                    System.out.println("=========================================");
-                    System.out.println("Modelix model plugin: Download model task");
-                    System.out.println("=========================================");
-                    System.out.println("  using existing MPS      : " + usingExistingMPS);
-                    System.out.println("  mps location            : " + mpsLocation);
-                    System.out.println("  mps extensions location : " + mpsExtensionsLocation);
-                    System.out.println("  modelix location        : " + modelixLocation);
-                    System.out.println("  server URL              : " + settings.getServerUrl());
-                    System.out.println("  repository ID           : " + settings.getRepositoryId());
-                    System.out.println("  branch name             : " + settings.getBranchName());
-                    System.out.println("  additional libraries    : " + settings.getAdditionalLibrariesAsString());
-                    System.out.println("  additional library dirs : " + settings.getAdditionalLibraryDirsAsString());
-                    System.out.println("  additional plugins      : " + settings.getAdditionalPluginsAsString());
-                    System.out.println("  additional plugin dirs  : " + settings.getAdditionalPluginDirsAsString());
-                    System.out.println("  project path            : " + settings.getProjectFile().getAbsolutePath());
                     System.out.println("  JVM Args                : " + javaExec.getJvmArgs());
                     System.out.println("  all JVM Args            : " + javaExec.getAllJvmArgs());
                     System.out.println("  Args                    : " + javaExec.getArgs());

--- a/gradle-plugin/src/main/java/org/modelix/gradle/model/ModelixModelSettings.java
+++ b/gradle-plugin/src/main/java/org/modelix/gradle/model/ModelixModelSettings.java
@@ -66,6 +66,7 @@ public class ModelixModelSettings {
     private String serverUrl = "http://localhost:28101/";
     private String repositoryId = "default";
     private String branchName = "master";
+    private String projectPath = null;
     private boolean debug = false;
     private int timeoutSeconds = 120;
 
@@ -116,9 +117,19 @@ public class ModelixModelSettings {
         return this.mpsPath;
     }
 
+    public File getProjectFile() {
+        if (this.projectPath == null) {
+            return null;
+        }
+        return new File(this.projectPath);
+    }
+
     public void setMpsPath(String mpsPath) {
-        System.out.println("setting MPS Path");
         this.mpsPath = mpsPath;
+    }
+
+    public void setProjectPath(String projectPath) {
+        this.projectPath = projectPath;
     }
 
     public String getMpsExtensionsArtifactsPath() {

--- a/mps/org.modelix.model.mpsplugin/models/org.modelix.model.mpsplugin.mps
+++ b/mps/org.modelix.model.mpsplugin/models/org.modelix.model.mpsplugin.mps
@@ -11472,13 +11472,25 @@
           </node>
           <node concept="9aQIb" id="5mIc0gCniGb" role="9aQIa">
             <node concept="3clFbS" id="5mIc0gCniGc" role="9aQI4">
-              <node concept="3clFbF" id="32pQaardmhE" role="3cqZAp">
-                <node concept="2OqwBi" id="32pQaardmms" role="3clFbG">
-                  <node concept="37vLTw" id="32pQaardmhC" role="2Oq$k0">
+              <node concept="3clFbJ" id="1UvRDkP6Raf" role="3cqZAp">
+                <node concept="3clFbS" id="1UvRDkP6Rah" role="3clFbx">
+                  <node concept="3clFbF" id="32pQaardmhE" role="3cqZAp">
+                    <node concept="2OqwBi" id="32pQaardmms" role="3clFbG">
+                      <node concept="37vLTw" id="32pQaardmhC" role="2Oq$k0">
+                        <ref role="3cqZAo" node="32pQaardcm5" resolve="virtualFile" />
+                      </node>
+                      <node concept="liA8E" id="32pQaardn5P" role="2OqNvi">
+                        <ref role="37wK5l" to="3ju5:~IFile.delete()" resolve="delete" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="1UvRDkP6T6x" role="3clFbw">
+                  <node concept="37vLTw" id="1UvRDkP6S5C" role="2Oq$k0">
                     <ref role="3cqZAo" node="32pQaardcm5" resolve="virtualFile" />
                   </node>
-                  <node concept="liA8E" id="32pQaardn5P" role="2OqNvi">
-                    <ref role="37wK5l" to="3ju5:~IFile.delete()" resolve="delete" />
+                  <node concept="liA8E" id="1UvRDkP6TUH" role="2OqNvi">
+                    <ref role="37wK5l" to="3ju5:~IFile.exists()" resolve="exists" />
                   </node>
                 </node>
               </node>


### PR DESCRIPTION
When downloading a model using the gradle plugin we need the concepts to be available. One way is to load the corresponding languages from a plugin, however in some cases we may want to get languages we have not packaged into plugins. To do that we can specify a project to open in the headless MPS used to export models. In this way we get access to the languages defined in the project and we also get access to all the libraries specified in the project. In this way configuring the download task is much easier.

For example:

```
modelixModel {
    serverUrl = "https://myserver.com/"
    repositoryId = "repo4"
    timeout = 25000
    projectPath = "myrepos/MyProject"
    mpsPath = "myrepos/MyProjec/artifacts/mps"
    
    // no need to package languages from MyProject into plugins and load them
    // no need to specify all the libraries used by MyProject
}
```