### PR TITLE
Correct how we check output lines

### DIFF
--- a/gradle-plugin/src/main/java/org/modelix/gradle/model/ModelPlugin.java
+++ b/gradle-plugin/src/main/java/org/modelix/gradle/model/ModelPlugin.java
@@ -140,7 +140,7 @@ public class ModelPlugin implements Plugin<Project> {
                     }
                     if (!success) {
                         System.err.println("Execution of ExportMain does not indicate success");
-                        throw new RuntimeException();
+                        throw new RuntimeException("We could not find the output lines indicating successful completion");
                     }
                     if (exitValue != 0) {
                         System.err.println("Execution of ExportMain failed. Exit code: " + exitValue);

--- a/gradle-plugin/src/main/java/org/modelix/gradle/model/ModelPlugin.java
+++ b/gradle-plugin/src/main/java/org/modelix/gradle/model/ModelPlugin.java
@@ -140,7 +140,7 @@ public class ModelPlugin implements Plugin<Project> {
                     }
                     if (!success) {
                         System.err.println("Execution of ExportMain does not indicate success");
-                        throw new RuntimeException("We could not find the output lines indicating successful completion");
+                        throw new RuntimeException("We could not find the output lines indicating successful completion. Lines found: " + outputLines);
                     }
                     if (exitValue != 0) {
                         System.err.println("Execution of ExportMain failed. Exit code: " + exitValue);

--- a/gradle-plugin/src/main/java/org/modelix/gradle/model/StreamContentCapture.java
+++ b/gradle-plugin/src/main/java/org/modelix/gradle/model/StreamContentCapture.java
@@ -43,7 +43,7 @@ class StreamContentCapture {
                 BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(bais));
                 String line;
                 while ((line = bufferedReader.readLine()) != null) {
-                    lines.add(line);
+                    lines.add(line.strip());
                 }
             }
             return this.lines;


### PR DESCRIPTION
Currently the gradle plugin launches Headless MPS and then check it completed correctly.
Unfortuntately the exit code is always zero, so we rely on checking a certain line to be present. This works on my Mac but seems not to work on the CI machine using presumably Linux. The line is actually print on the console but for some reason it is not found by the check and this cause the task to fail. I suspect it may be because newlines are handled differently, so I am adding a strip.

I am also open to better alternatives to get this communication mechanism working