### PR TITLE
Build the modelix base image also for arm64

### DIFF
--- a/Dockerfile-mps
+++ b/Dockerfile-mps
@@ -13,8 +13,18 @@ RUN { echo '#/bin/sh'; echo 'echo "$JAVA_HOME"'; } > /usr/local/bin/docker-java-
 ENV PATH $JAVA_HOME/bin:$PATH
 
 RUN set -eux; \
+  arch="$(dpkg --print-architecture)"; \
+  echo $arch; \
+  case "$arch" in \
+		'amd64') \
+	    downloadUrl='https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11_0_10-linux-x64-b1145.96.tar.gz'; \
+			;; \
+		'arm64') \
+      downloadUrl='https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_11-linux-aarch64-b1504.16.tar.gz'; \
+			;; \
+		*) echo >&2 "error: unsupported architecture: '$arch'"; exit 1 ;; \
+	esac; \
 	\
-	downloadUrl='https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11_0_10-linux-x64-b1145.96.tar.gz'; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \

--- a/docker-build-model.sh
+++ b/docker-build-model.sh
@@ -6,7 +6,9 @@ TAG=$( ./modelix-version.sh )
 
 (
   cd model-server
-  docker build --no-cache -t modelix/modelix-model .
+ # docker build --no-cache -t modelix/modelix-model .
+  DOCKER_BUILDKIT=1 docker buildx build --platform linux/amd64,linux/arm64 --no-cache -t modelix/modelix-model .
+
 )
 
 docker tag modelix/modelix-model:latest "modelix/modelix-model:${TAG}"

--- a/docker-build-mps.sh
+++ b/docker-build-mps.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-docker build -f Dockerfile-mps -t modelix/modelix-mps .
+docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile-mps -t modelix/modelix-mps .
+


### PR DESCRIPTION
By default modelix currently only builds docker images for amd64.

To be able to run docker images based on base image I suggest the changes below which contain a check for the target architecture in Dockerfile-mps and changes to the build scripts which add arm64 as a target platform.
