### PR TITLE
Enable local arm64 builds

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -4,5 +4,5 @@ WORKDIR /usr/modelix-ui
 COPY artifacts/de.itemis.mps.extensions/ /mps-plugins/de.itemis.mps.extensions/
 
 COPY build/org.modelix/build/artifacts/org.modelix/plugins/ /mps-plugins/modelix-base/
-RUN rm -rf /mps-plugins/modelix-base/org.modelix.ui.server
-RUN /install-plugins.sh
+RUN rm -rf /mps-plugins/modelix-base/org.modelix.ui.server \
+  && /install-plugins.sh

--- a/Dockerfile-mps
+++ b/Dockerfile-mps
@@ -1,13 +1,10 @@
 FROM debian:buster
 ARG TARGETARCH
 
-RUN set -eux; apt-get update; apt-get install -y --no-install-recommends ca-certificates curl netbase wget; rm -rf /var/lib/apt/lists/*
-
-RUN set -ex; if ! command -v gpg > /dev/null; then apt-get update; apt-get install -y --no-install-recommends gnupg dirmngr; rm -rf /var/lib/apt/lists/*; fi
-
-RUN apt-get update && apt-get install -y --no-install-recommends git mercurial openssh-client subversion procps && rm -rf /var/lib/apt/lists/*
-RUN set -eux; apt-get update; apt-get install -y --no-install-recommends bzip2 unzip xz-utils fontconfig libfreetype6 ca-certificates p11-kit; rm -rf /var/lib/apt/lists/*
-
+RUN set -eux \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl netbase wget gnupg dirmngr git mercurial openssh-client subversion procps bzip2 unzip xz-utils fontconfig libfreetype6 ca-certificates p11-kit zip\
+    && rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME /usr/local/jbr
 RUN { echo '#/bin/sh'; echo 'echo "$JAVA_HOME"'; } > /usr/local/bin/docker-java-home && chmod +x /usr/local/bin/docker-java-home && [ "$JAVA_HOME" = "$(docker-java-home)" ] # backwards compatibility
@@ -77,6 +74,16 @@ RUN set -eux; \
 
 WORKDIR /usr/modelix-ui
 COPY artifacts/mps/ /usr/modelix-ui/mps/
+
+# Enable error markers in headless mode
+RUN apt update && apt install -y zip
+RUN mkdir -p /tmp/mps-workbench
+RUN unzip /usr/modelix-ui/mps/lib/mps-workbench.jar -d /tmp/mps-workbench/
+RUN sed -i '/jetbrains.mps.nodeEditor.EmptyHighlighter/d' /tmp/mps-workbench/META-INF/MPSEditor.xml
+RUN rm /usr/modelix-ui/mps/lib/mps-workbench.jar
+WORKDIR /tmp/mps-workbench/
+RUN zip -r /usr/modelix-ui/mps/lib/mps-workbench.jar ./*
+RUN rm -rf /tmp/mps-workbench/
 
 COPY install-plugins.sh /
 RUN chmod +x /install-plugins.sh

--- a/Dockerfile-mps
+++ b/Dockerfile-mps
@@ -3,7 +3,10 @@ ARG TARGETARCH
 
 RUN set -eux \
     && apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates curl netbase wget gnupg dirmngr git mercurial openssh-client subversion procps bzip2 unzip xz-utils fontconfig libfreetype6 ca-certificates p11-kit zip\
+    && apt-get install -y --no-install-recommends ca-certificates  \
+    curl netbase wget gnupg dirmngr git mercurial openssh-client  \
+    subversion procps bzip2 unzip xz-utils fontconfig libfreetype6  \
+    ca-certificates p11-kit zip \
     && rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME /usr/local/jbr

--- a/Dockerfile-mps
+++ b/Dockerfile-mps
@@ -1,4 +1,5 @@
 FROM debian:buster
+ARG TARGETARCH
 
 RUN set -eux; apt-get update; apt-get install -y --no-install-recommends ca-certificates curl netbase wget; rm -rf /var/lib/apt/lists/*
 
@@ -14,7 +15,16 @@ ENV PATH $JAVA_HOME/bin:$PATH
 
 RUN set -eux; \
 	\
-	downloadUrl='https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11_0_10-linux-x64-b1145.96.tar.gz'; \
+	case "$TARGETARCH" in \
+	    'amd64' ) \
+	        downloadUrl='https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11_0_10-linux-x64-b1145.96.tar.gz'; \
+	        ;; \
+	    'arm64' ) \
+	        downloadUrl='https://cache-redirector.jetbrains.com/intellij-jbr/jbr-11_0_11-linux-aarch64-b1341.60.tar.gz'; \
+	        ;; \
+	    * ) \
+	        echo >&2 "error: unsupported target architecture '$TARGETARCH'"; exit 1 ;; \
+	esac; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \

--- a/Dockerfile-projector
+++ b/Dockerfile-projector
@@ -11,9 +11,8 @@ COPY projector-user-home /home/projector-user
 RUN mv "/home/projector-user/.config/JetBrains/MPSxxxx.x" "/home/projector-user/.config/JetBrains/MPS$(grep "mpsBootstrapCore.version=" /projector/ide/build.properties|cut -d'=' -f2)"
 COPY log.xml /projector/ide/bin/log.xml
 
-RUN chown -R projector-user:projector-user /home/projector-user
-RUN chown -R projector-user:projector-user /mps-plugins
-RUN chown -R projector-user:projector-user /mps-languages
-RUN chown -R projector-user:projector-user /projector/ide/
-
+RUN chown -R projector-user:projector-user /home/projector-user \
+  && chown -R projector-user:projector-user /mps-plugins \
+  && chown -R projector-user:projector-user /mps-languages \
+  && chown -R projector-user:projector-user /projector/ide/
 USER projector-user

--- a/Dockerfile-projector-base
+++ b/Dockerfile-projector-base
@@ -9,17 +9,15 @@ COPY build/branding.zip /projector/ide/lib/branding.jar
 RUN apt-get update \
     && apt-get install unzip -y \
     && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /var/cache/apt
-
-RUN echo "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5071" >> /projector/ide/bin/mps64.vmoptions
-RUN sed -i.bak '/-Xmx/d' /projector/ide/bin/mps64.vmoptions
-RUN echo "-XX:MaxRAMPercentage=85" >> /projector/ide/bin/mps64.vmoptions
-
-RUN mkdir -p /mps-plugins
-RUN mkdir -p /mps-languages
-RUN chown -R projector-user:projector-user /home/projector-user
-RUN chown -R projector-user:projector-user /mps-plugins
-RUN chown -R projector-user:projector-user /mps-languages
-RUN chown -R projector-user:projector-user /projector/ide/
+    && rm -rf /var/cache/apt \
+    && echo "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5071" >> /projector/ide/bin/mps64.vmoptions \
+    && sed -i.bak '/-Xmx/d' /projector/ide/bin/mps64.vmoptions \
+    && echo "-XX:MaxRAMPercentage=85" >> /projector/ide/bin/mps64.vmoptions \
+    && mkdir -p /mps-plugins \
+    && mkdir -p /mps-languages \
+    && chown -R projector-user:projector-user /home/projector-user \
+    && chown -R projector-user:projector-user /mps-plugins \
+    && chown -R projector-user:projector-user /mps-languages \
+    && chown -R projector-user:projector-user /projector/ide/
 
 USER projector-user

--- a/Dockerfile-workspace-manager
+++ b/Dockerfile-workspace-manager
@@ -1,9 +1,6 @@
 FROM openjdk:11
 
-RUN apt update
-RUN apt install maven -y
-RUN apt install git -y
-RUN apt install ant -y
+RUN apt update && apt install -y maven git ant
 
 COPY bundled-maven-dependencies/pom.xml /bundled-maven-dependencies/pom.xml
 WORKDIR /bundled-maven-dependencies

--- a/docker-build-base.sh
+++ b/docker-build-base.sh
@@ -3,5 +3,5 @@
 TAG=$( ./modelix-version.sh )
 MODELIX_TARGET_PLATFORM="${MODELIX_TARGET_PLATFORM:=linux/amd64}"
 
-docker build --platform ${MODELIX_TARGET_PLATFORM:-linux/amd64} --no-cache -f Dockerfile-base -t modelix/modelix-base .
+docker build --platform ${MODELIX_TARGET_PLATFORM} --no-cache -f Dockerfile-base -t modelix/modelix-base .
 docker tag modelix/modelix-base:latest "modelix/modelix-base:${TAG}"

--- a/docker-build-base.sh
+++ b/docker-build-base.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 TAG=$( ./modelix-version.sh )
+MODELIX_TARGET_PLATFORM="${MODELIX_TARGET_PLATFORM:=linux/amd64}"
 
-docker build --platform ${MODELIX_TARGET_PLATFORM} --no-cache -f Dockerfile-base -t modelix/modelix-base .
+docker build --platform ${MODELIX_TARGET_PLATFORM:-linux/amd64} --no-cache -f Dockerfile-base -t modelix/modelix-base .
 docker tag modelix/modelix-base:latest "modelix/modelix-base:${TAG}"

--- a/docker-build-base.sh
+++ b/docker-build-base.sh
@@ -2,5 +2,5 @@
 
 TAG=$( ./modelix-version.sh )
 
-docker build --no-cache -f Dockerfile-base -t modelix/modelix-base .
+docker build --platform=linux/amd64 --no-cache -f Dockerfile-base -t modelix/modelix-base .
 docker tag modelix/modelix-base:latest "modelix/modelix-base:${TAG}"

--- a/docker-build-base.sh
+++ b/docker-build-base.sh
@@ -2,5 +2,5 @@
 
 TAG=$( ./modelix-version.sh )
 
-docker build --platform=linux/amd64 --no-cache -f Dockerfile-base -t modelix/modelix-base .
+docker build --platform ${MODELIX_TARGET_PLATFORM} --no-cache -f Dockerfile-base -t modelix/modelix-base .
 docker tag modelix/modelix-base:latest "modelix/modelix-base:${TAG}"

--- a/docker-build-db.sh
+++ b/docker-build-db.sh
@@ -3,7 +3,7 @@
 TAG=$( ./modelix-version.sh )
 
 cd db
-docker build --no-cache -f Dockerfile -t modelix/modelix-db .
+docker build --platform=linux/amd64 --no-cache -f Dockerfile -t modelix/modelix-db .
 
 cd ..
 docker tag modelix/modelix-db:latest "modelix/modelix-db:${TAG}"

--- a/docker-build-db.sh
+++ b/docker-build-db.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 TAG=$( ./modelix-version.sh )
+MODELIX_TARGET_PLATFORM="${MODELIX_TARGET_PLATFORM:=linux/amd64}"
 
 cd db
 docker build --platform ${MODELIX_TARGET_PLATFORM} --no-cache -f Dockerfile -t modelix/modelix-db .

--- a/docker-build-db.sh
+++ b/docker-build-db.sh
@@ -3,7 +3,7 @@
 TAG=$( ./modelix-version.sh )
 
 cd db
-docker build --platform=linux/amd64 --no-cache -f Dockerfile -t modelix/modelix-db .
+docker build --platform ${MODELIX_TARGET_PLATFORM} --no-cache -f Dockerfile -t modelix/modelix-db .
 
 cd ..
 docker tag modelix/modelix-db:latest "modelix/modelix-db:${TAG}"

--- a/docker-build-instances-manager.sh
+++ b/docker-build-instances-manager.sh
@@ -6,7 +6,7 @@ TAG=$( ./modelix-version.sh )
 
 (
   cd instances-manager
-  docker build --platform=linux/amd64 --no-cache -t modelix/modelix-instances-manager .
+  docker build --platform ${MODELIX_TARGET_PLATFORM} --no-cache -t modelix/modelix-instances-manager .
 )
 
 docker tag modelix/modelix-instances-manager:latest "modelix/modelix-instances-manager:${TAG}"

--- a/docker-build-instances-manager.sh
+++ b/docker-build-instances-manager.sh
@@ -3,6 +3,7 @@
 set -e
 
 TAG=$( ./modelix-version.sh )
+MODELIX_TARGET_PLATFORM="${MODELIX_TARGET_PLATFORM:=linux/amd64}"
 
 (
   cd instances-manager

--- a/docker-build-instances-manager.sh
+++ b/docker-build-instances-manager.sh
@@ -6,7 +6,7 @@ TAG=$( ./modelix-version.sh )
 
 (
   cd instances-manager
-  docker build --no-cache -t modelix/modelix-instances-manager .
+  docker build --platform=linux/amd64 --no-cache -t modelix/modelix-instances-manager .
 )
 
 docker tag modelix/modelix-instances-manager:latest "modelix/modelix-instances-manager:${TAG}"

--- a/docker-build-keycloak.sh
+++ b/docker-build-keycloak.sh
@@ -3,6 +3,7 @@
 set -e
 
 TAG=$( ./modelix-version.sh )
+MODELIX_TARGET_PLATFORM="${MODELIX_TARGET_PLATFORM:=linux/amd64}"
 
 (
   cd keycloak-extensions

--- a/docker-build-keycloak.sh
+++ b/docker-build-keycloak.sh
@@ -6,7 +6,7 @@ TAG=$( ./modelix-version.sh )
 
 (
   cd keycloak-extensions
-  docker build -t modelix/keycloak .
+  docker build --platform=linux/amd64 -t modelix/keycloak .
 )
 
 docker tag modelix/keycloak:latest "modelix/keycloak:${TAG}"

--- a/docker-build-keycloak.sh
+++ b/docker-build-keycloak.sh
@@ -6,7 +6,7 @@ TAG=$( ./modelix-version.sh )
 
 (
   cd keycloak-extensions
-  docker build --platform=linux/amd64 -t modelix/keycloak .
+  docker build --platform ${MODELIX_TARGET_PLATFORM} -t modelix/keycloak .
 )
 
 docker tag modelix/keycloak:latest "modelix/keycloak:${TAG}"

--- a/docker-build-mps.sh
+++ b/docker-build-mps.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker build --platform=linux/amd64 -f Dockerfile-mps -t modelix/modelix-mps .
+docker build --platform ${MODELIX_TARGET_PLATFORM} -f Dockerfile-mps -t modelix/modelix-mps .

--- a/docker-build-mps.sh
+++ b/docker-build-mps.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker build -f Dockerfile-mps -t modelix/modelix-mps .
+docker build --platform=linux/amd64 -f Dockerfile-mps -t modelix/modelix-mps .

--- a/docker-build-mps.sh
+++ b/docker-build-mps.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 
+MODELIX_TARGET_PLATFORM="${MODELIX_TARGET_PLATFORM:=linux/amd64}"
+
 docker build --platform ${MODELIX_TARGET_PLATFORM} -f Dockerfile-mps -t modelix/modelix-mps .

--- a/docker-build-projector-base.sh
+++ b/docker-build-projector-base.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+MODELIX_TARGET_PLATFORM="${MODELIX_TARGET_PLATFORM:=linux/amd64}"
+
 # read variables from mps-version.properties
 while IFS='=' read -r key value
 do

--- a/docker-build-projector-base.sh
+++ b/docker-build-projector-base.sh
@@ -26,4 +26,4 @@ unzip -d build/branding artifacts/mps/lib/branding.jar
   zip -r ../branding.zip ./*
 )
 
-docker build --no-cache -f Dockerfile-projector-base -t modelix/modelix-projector-base .
+docker build --platform=linux/amd64 --no-cache -f Dockerfile-projector-base -t modelix/modelix-projector-base .

--- a/docker-build-projector-base.sh
+++ b/docker-build-projector-base.sh
@@ -26,4 +26,4 @@ unzip -d build/branding artifacts/mps/lib/branding.jar
   zip -r ../branding.zip ./*
 )
 
-docker build --platform=linux/amd64 --no-cache -f Dockerfile-projector-base -t modelix/modelix-projector-base .
+docker build --platform ${MODELIX_TARGET_PLATFORM} --no-cache -f Dockerfile-projector-base -t modelix/modelix-projector-base .

--- a/docker-build-projector-mps.sh
+++ b/docker-build-projector-mps.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+MODELIX_TARGET_PLATFORM="${MODELIX_TARGET_PLATFORM:=linux/amd64}"
+
 # read variables from mps-version.properties
 while IFS='=' read -r key value
 do

--- a/docker-build-projector.sh
+++ b/docker-build-projector.sh
@@ -4,6 +4,6 @@ set -e
 
 TAG=$( ./modelix-version.sh )
 
-docker build --platform=linux/amd64 --no-cache -f Dockerfile-projector -t modelix/modelix-projector .
+docker build --platform ${MODELIX_TARGET_PLATFORM} --no-cache -f Dockerfile-projector -t modelix/modelix-projector .
 
 docker tag modelix/modelix-projector:latest "modelix/modelix-projector:${TAG}"

--- a/docker-build-projector.sh
+++ b/docker-build-projector.sh
@@ -3,6 +3,7 @@
 set -e
 
 TAG=$( ./modelix-version.sh )
+MODELIX_TARGET_PLATFORM="${MODELIX_TARGET_PLATFORM:=linux/amd64}"
 
 docker build --platform ${MODELIX_TARGET_PLATFORM} --no-cache -f Dockerfile-projector -t modelix/modelix-projector .
 

--- a/docker-build-projector.sh
+++ b/docker-build-projector.sh
@@ -4,6 +4,6 @@ set -e
 
 TAG=$( ./modelix-version.sh )
 
-docker build --no-cache -f Dockerfile-projector -t modelix/modelix-projector .
+docker build --platform=linux/amd64 --no-cache -f Dockerfile-projector -t modelix/modelix-projector .
 
 docker tag modelix/modelix-projector:latest "modelix/modelix-projector:${TAG}"

--- a/docker-build-proxy.sh
+++ b/docker-build-proxy.sh
@@ -3,6 +3,7 @@
 set -e
 
 TAG=$( ./modelix-version.sh )
+MODELIX_TARGET_PLATFORM="${MODELIX_TARGET_PLATFORM:=linux/amd64}"
 
 (
 #  cd proxy

--- a/docker-build-proxy.sh
+++ b/docker-build-proxy.sh
@@ -6,7 +6,7 @@ TAG=$( ./modelix-version.sh )
 
 (
 #  cd proxy
-  docker build --platform=linux/amd64 -f Dockerfile-proxy --no-cache -t modelix/modelix-proxy .
+  docker build --platform ${MODELIX_TARGET_PLATFORM} -f Dockerfile-proxy --no-cache -t modelix/modelix-proxy .
 )
 
 docker tag modelix/modelix-proxy:latest "modelix/modelix-proxy:${TAG}"

--- a/docker-build-proxy.sh
+++ b/docker-build-proxy.sh
@@ -6,7 +6,7 @@ TAG=$( ./modelix-version.sh )
 
 (
 #  cd proxy
-  docker build -f Dockerfile-proxy --no-cache -t modelix/modelix-proxy .
+  docker build --platform=linux/amd64 -f Dockerfile-proxy --no-cache -t modelix/modelix-proxy .
 )
 
 docker tag modelix/modelix-proxy:latest "modelix/modelix-proxy:${TAG}"

--- a/docker-build-workspace-client.sh
+++ b/docker-build-workspace-client.sh
@@ -4,7 +4,7 @@ set -e
 
 TAG=$( ./modelix-version.sh )
 
-docker build -f Dockerfile-workspace-client -t modelix/modelix-workspace-client .
+docker build --platform=linux/amd64 -f Dockerfile-workspace-client -t modelix/modelix-workspace-client .
 
 docker tag modelix/modelix-workspace-client:latest "modelix/modelix-workspace-client:${TAG}"
 

--- a/docker-build-workspace-client.sh
+++ b/docker-build-workspace-client.sh
@@ -3,6 +3,7 @@
 set -e
 
 TAG=$( ./modelix-version.sh )
+MODELIX_TARGET_PLATFORM="${MODELIX_TARGET_PLATFORM:=linux/amd64}"
 
 docker build --platform ${MODELIX_TARGET_PLATFORM} -f Dockerfile-workspace-client -t modelix/modelix-workspace-client .
 

--- a/docker-build-workspace-client.sh
+++ b/docker-build-workspace-client.sh
@@ -4,7 +4,7 @@ set -e
 
 TAG=$( ./modelix-version.sh )
 
-docker build --platform=linux/amd64 -f Dockerfile-workspace-client -t modelix/modelix-workspace-client .
+docker build --platform ${MODELIX_TARGET_PLATFORM} -f Dockerfile-workspace-client -t modelix/modelix-workspace-client .
 
 docker tag modelix/modelix-workspace-client:latest "modelix/modelix-workspace-client:${TAG}"
 

--- a/docker-build-workspace-manager.sh
+++ b/docker-build-workspace-manager.sh
@@ -4,7 +4,7 @@ set -e
 
 TAG=$( ./modelix-version.sh )
 
-docker build -f Dockerfile-workspace-manager -t modelix/modelix-workspace-manager .
+docker build --platform=linux/amd64 -f Dockerfile-workspace-manager -t modelix/modelix-workspace-manager .
 
 docker tag modelix/modelix-workspace-manager:latest "modelix/modelix-workspace-manager:${TAG}"
 

--- a/docker-build-workspace-manager.sh
+++ b/docker-build-workspace-manager.sh
@@ -4,7 +4,7 @@ set -e
 
 TAG=$( ./modelix-version.sh )
 
-docker build --platform=linux/amd64 -f Dockerfile-workspace-manager -t modelix/modelix-workspace-manager .
+docker build --platform ${MODELIX_TARGET_PLATFORM} -f Dockerfile-workspace-manager -t modelix/modelix-workspace-manager .
 
 docker tag modelix/modelix-workspace-manager:latest "modelix/modelix-workspace-manager:${TAG}"
 

--- a/docker-build-workspace-manager.sh
+++ b/docker-build-workspace-manager.sh
@@ -3,6 +3,7 @@
 set -e
 
 TAG=$( ./modelix-version.sh )
+MODELIX_TARGET_PLATFORM="${MODELIX_TARGET_PLATFORM:=linux/amd64}"
 
 docker build --platform ${MODELIX_TARGET_PLATFORM} -f Dockerfile-workspace-manager -t modelix/modelix-workspace-manager .
 


### PR DESCRIPTION
These changes allow devs who use M1 macs to locally build arm64 docker images.
Also includes som docker file optimizations by merging `RUN` statements
Building for arm64 requires the environment variable `MODELIX_TARGET_PLATFORM` to be set to `linux/arm64`.
The default value for this variable is `linux/amd64`.
Therefore other devs and CI should be unaffected by these changes.