### PR TITLE
MODELIX-519 MPS 2021.3 startup was prevented by EUA dialog

### DIFF
--- a/Dockerfile-projector
+++ b/Dockerfile-projector
@@ -29,7 +29,6 @@ RUN echo "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5071" 
 
 USER projector-user
 
-RUN /install-plugins.sh /projector/ide/plugins/
 COPY --chown=projector-user:projector-user projector-user-home /home/projector-user
 # rename config directory to match the correct MPS version
 RUN mv "/home/projector-user/.config/JetBrains/MPSxxxx.x" "/home/projector-user/.config/JetBrains/MPS$(grep "mpsBootstrapCore.version=" /projector/ide/build.properties|cut -d'=' -f2)"
@@ -38,3 +37,5 @@ COPY --chown=projector-user:projector-user log.xml /projector/ide/bin/log.xml
 
 COPY --chown=projector-user:projector-user artifacts/de.itemis.mps.extensions/ /mps-plugins/MPS-extensions
 COPY --chown=projector-user:projector-user build/org.modelix/build/artifacts/org.modelix/plugins/ /mps-plugins/modelix
+
+RUN /install-plugins.sh /projector/ide/plugins/

--- a/Dockerfile-projector
+++ b/Dockerfile-projector
@@ -27,11 +27,21 @@ RUN echo "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5071" 
     && chown -R projector-user:projector-user /mps-languages \
     && chown -R projector-user:projector-user /projector/ide/
 
+# An "End User Agreement" dialog prevents the startup if the vendor name is 'JetBrains'
+# See
+# - https://github.com/JetBrains/intellij-community/blob/777669cc01eb14e6fcf2ed3ba11d2c1d3832d6e2/platform/platform-impl/src/com/intellij/idea/eua.kt#L19-L20
+# - https://github.com/JetBrains/MPS/blob/418307944be761dd1e62af65881c8eade086386f/plugins/mps-build/solutions/mpsBuild/source_gen/jetbrains/mps/ide/build/mps.sh#L224
+# - https://github.com/JetBrains/MPS/blob/418307944be761dd1e62af65881c8eade086386f/plugins/mps-build/solutions/mpsBuild/source_gen/jetbrains/mps/ide/build/mps.sh#L57
+RUN sed -i.bak "s/IDEA_VENDOR_NAME='JetBrains'/IDEA_VENDOR_NAME='Modelix'/g" /projector/ide/bin/mps.sh
+
 USER projector-user
 
 COPY --chown=projector-user:projector-user projector-user-home /home/projector-user
 # rename config directory to match the correct MPS version
 RUN mv "/home/projector-user/.config/JetBrains/MPSxxxx.x" "/home/projector-user/.config/JetBrains/MPS$(grep "mpsBootstrapCore.version=" /projector/ide/build.properties|cut -d'=' -f2)"
+
+# changing the vendor name (see above) also changes the location of the config dir
+RUN ln -s /home/projector-user/.config/JetBrains /home/projector-user/.config/Modelix
 
 COPY --chown=projector-user:projector-user log.xml /projector/ide/bin/log.xml
 


### PR DESCRIPTION
They now read the vendor from the system property `idea.vendor.name` instead of just the `ApplicationInfo.xml`. See
https://github.com/JetBrains/intellij-community/blob/777669cc01eb14e6fcf2ed3ba11d2c1d3832d6e2/platform/platform-impl/src/com/intellij/idea/eua.kt#L19