### PR TITLE
ci: do not publish Maven artifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,12 +19,8 @@ jobs:
         java-version: '11'
     - name: Use tag as version
       run: echo "${GITHUB_REF#refs/*/}" > modelix.version
-    - name: Build and Publish Maven
-      env:
-        NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
-        NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: ./gradlew assemble publish -Partifacts.itemis.cloud.user=${{secrets.ARTIFACTS_ITEMIS_CLOUD_USER}} -Partifacts.itemis.cloud.pw=${{secrets.ARTIFACTS_ITEMIS_CLOUD_PW}}
+    - name: Assemble Maven
+      run: ./gradlew assemble
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx


### PR DESCRIPTION
Maven artifacts are now published from https://github.com/modelix/modelix.mps

The "Publish" workflow should only publish Docker images and Helm charts.